### PR TITLE
Add InChI 1.07's new tautomer options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,12 @@ jobs:
           repository: 'IUPAC-InChI/InChI'
           ref: 'v1.06'
 
-      - name: Checkout v1.07-beta from InChI repository
+      - name: Checkout v1.07 from InChI repository
         uses: actions/checkout@v4
         with:
           path: './InChI_1_07'
           repository: 'IUPAC-InChI/InChI'
-          ref: 'v1.07-RC1'
+          ref: 'v1.07-RC2'
 
       #
       # Compile v1.06's INCHI_EXE and run the test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,23 @@ jobs:
           unzip bootstrap-icons-1.10.3.zip -d bootstrap-icons
 
       #
+      # Bootstrap Multiselect
+      #
+      - name: Download Bootstrap Multiselect
+        run: |
+          cd $GITHUB_WORKSPACE
+          wget -O bootstrap-multiselect.zip https://github.com/davidstutz/bootstrap-multiselect/archive/refs/tags/v1.1.2.zip
+          unzip bootstrap-multiselect.zip -d bootstrap-multiselect
+
+      #
+      # JQuery
+      #
+      - name: Download JQuery
+        run: |
+          cd $GITHUB_WORKSPACE
+          wget -P jquery https://code.jquery.com/jquery-3.7.1.min.js
+
+      #
       # GitHub pages deployment
       #
       - name: Collect artifacts for deployment
@@ -174,6 +191,8 @@ jobs:
           cp -R $GITHUB_WORKSPACE/InChI-Web-Demo/ketcher/react-app/build/* ketcher
           cp -R $GITHUB_WORKSPACE/bootstrap .
           cp -R $GITHUB_WORKSPACE/bootstrap-icons .
+          cp -R $GITHUB_WORKSPACE/bootstrap-multiselect/bootstrap-multiselect-*/dist bootstrap-multiselect
+          cp -R $GITHUB_WORKSPACE/jquery .
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/pages/.gitignore
+++ b/pages/.gitignore
@@ -1,5 +1,7 @@
 bootstrap/
 bootstrap-icons/
+bootstrap-multiselect/
+jquery/
+ketcher/
 inchi/
 rinchi/
-ketcher/

--- a/pages/css/index.css
+++ b/pages/css/index.css
@@ -20,6 +20,16 @@ input.form-check-input:is([type="checkbox"], [type="radio"]):checked {
   border-color: #00612c;
 }
 
+/*
+ * Used when at least one item is selected in Bootstrap Multiselect.
+ * Background image is a copy from Bootstrap with altered color ("stroke").
+ */
+button.form-select.multiselect:has(~ div.multiselect-container > button.active)  {
+  color: #ffffff;
+  background-color: #9db668;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+}
+
 input.form-check-input:is([type="checkbox"], [type="radio"]):focus,
 select.form-select:focus,
 textarea.form-control:focus,

--- a/pages/css/index.css
+++ b/pages/css/index.css
@@ -22,7 +22,8 @@ input.form-check-input:is([type="checkbox"], [type="radio"]):checked {
 
 input.form-check-input:is([type="checkbox"], [type="radio"]):focus,
 select.form-select:focus,
-textarea.form-control:focus {
+textarea.form-control:focus,
+button.form-select.multiselect:focus {
   border-color: #7e9849;
   box-shadow: 0 0 0 0.25rem rgba(126, 152, 73, 0.25);
 }

--- a/pages/css/index.css
+++ b/pages/css/index.css
@@ -26,7 +26,7 @@ input.form-check-input:is([type="checkbox"], [type="radio"]):checked {
  */
 button.form-select.multiselect:has(~ div.multiselect-container > button.active)  {
   color: #ffffff;
-  background-color: #9db668;
+  background-color: #00612c;
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23ffffff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
 }
 

--- a/pages/inchi.js
+++ b/pages/inchi.js
@@ -8,7 +8,7 @@
  */
 const inchiModulePromises = {
   "1.06": inchiModule106(),
-  "1.07-RC1": inchiModule107()
+  "1.07-RC2": inchiModule107()
 };
 
 const availableInchiVersions = Object.keys(inchiModulePromises);

--- a/pages/index.html
+++ b/pages/index.html
@@ -76,7 +76,7 @@
                   <div data-inchi-options></div>
                   <div class="mt-2">
                     <label class="form-check-label mb-2" for="inchi-tab1-inchiversion">Select InChI version</label>
-                    <select id="inchi-tab1-inchiversion" class="form-select" data-version onchange="updateInchiTab1()"></select>
+                    <select id="inchi-tab1-inchiversion" class="form-select" data-version onchange="onChangeInChIVersionTab1()"></select>
                   </div>
                 </div>
               </div>
@@ -121,7 +121,7 @@
                   <div data-inchi-options></div>
                   <div class="mt-2">
                     <label class="form-check-label mb-2" for="inchi-tab2-inchiversion">Select InChI version</label>
-                    <select id="inchi-tab2-inchiversion" class="form-select" data-version onchange="updateInchiTab2()"></select>
+                    <select id="inchi-tab2-inchiversion" class="form-select" data-version onchange="onChangeInChIVersionTab2()"></select>
                   </div>
                 </div>
               </div>
@@ -475,8 +475,89 @@
 
     </div>
 
-    <!-- Template for InChI options -->
-    <template id="inchiOptionsTemplate">
+    <!-- Template for InChI 1.06 options -->
+    <template data-inchi-options-template-version="1.06">
+      <div class="form-check">
+        <input data-id="mobileH" class="form-check-input" type="checkbox" data-inchi-option-off="DoNotAddH" data-default-checked checked>
+        <label class="form-check-label">Mobile H Perception</label>
+      </div>
+      <div class="row row-cols-auto">
+        <div class="col">
+          <div class="form-check">
+            <input data-id="includeStereo" class="form-check-input" type="checkbox" data-inchi-option-off="SNon" data-default-checked checked>
+            <label class="form-check-label">Include Stereo:</label>
+          </div>
+        </div>
+        <div class="col">
+          <div class="form-check ms-xl-0 ms-lg-4">
+            <input data-id="SAbs" class="form-check-input" type="radio" name="stereoRadio" data-inchi-stereo-option data-default-checked checked>
+            <label class="form-check-label">Absolute</label>
+          </div>
+          <div class="form-check ms-xl-0 ms-lg-4">
+            <input data-id="SRel" class="form-check-input" type="radio" name="stereoRadio" data-inchi-option-on="SRel" data-inchi-stereo-option>
+            <label class="form-check-label">Relative</label>
+          </div>
+          <div class="form-check ms-xl-0 ms-lg-4">
+            <input data-id="SRac" class="form-check-input" type="radio" name="stereoRadio" data-inchi-option-on="SRac" data-inchi-stereo-option>
+            <label class="form-check-label">Racemic</label>
+          </div>
+          <div class="form-check ms-xl-0 ms-lg-4">
+            <input data-id="SUCF" class="form-check-input" type="radio" name="stereoRadio" data-inchi-option-on="SUCF" data-inchi-stereo-option>
+            <label class="form-check-label">From chiral flag</label>
+          </div>
+        </div>
+      </div>
+      <div class="form-check ms-4">
+        <input data-id="SUU" class="form-check-input" type="checkbox" data-inchi-option-on="SUU" data-inchi-stereo-option>
+        <label class="form-check-label">Always include omitted/undefined stereo</label>
+      </div>
+      <div class="form-check ms-4">
+        <input data-id="SLUUD" class="form-check-input" type="checkbox" data-inchi-option-on="SLUUD" data-inchi-stereo-option>
+        <label class="form-check-label">Different marks for unknown/undefined stereo</label>
+      </div>
+      <div class="form-check ms-4">
+        <input data-id="NEWPSOFF" class="form-check-input" type="checkbox" data-inchi-option-on="NEWPSOFF" data-inchi-stereo-option>
+        <label class="form-check-label">Both ends of wedge point to stereocenters</label>
+      </div>
+      <div class="form-check">
+        <input data-id="RecMet" class="form-check-input" type="checkbox" data-inchi-option-on="RecMet">
+        <label class="form-check-label">Include Bonds to Metal</label>
+      </div>
+      <div class="form-check">
+        <input data-id="KET" class="form-check-input" type="checkbox" data-inchi-option-on="KET">
+        <label class="form-check-label">Keto-enol Tautomerism</label>
+      </div>
+      <div class="form-check">
+        <input data-id="15T" class="form-check-input" type="checkbox" data-inchi-option-on="15T">
+        <label class="form-check-label">1,5-tautomerism</label>
+      </div>
+      <div class="form-check">
+        <input data-id="treatPolymers" class="form-check-input" type="checkbox" data-inchi-option-on="Polymers">
+        <label class="form-check-label">Treat polymers:</label>
+      </div>
+      <div class="form-check ms-4">
+        <input data-id="NoEdits" class="form-check-input" type="checkbox" data-inchi-option-on="NoEdits" data-inchi-polymer-option data-default-disabled disabled>
+        <label class="form-check-label">No pre-edits of original polymer structure</label>
+      </div>
+      <div class="form-check ms-4">
+        <input data-id="FoldCRU" class="form-check-input" type="checkbox" data-inchi-option-on="FoldCRU" data-inchi-polymer-option data-default-disabled disabled>
+        <label class="form-check-label">Enable CRU folding</label>
+      </div>
+      <div class="form-check ms-4">
+        <input data-id="NoFrameShift" class="form-check-input" type="checkbox" data-inchi-option-on="NoFrameShift" data-inchi-polymer-option data-default-disabled disabled>
+        <label class="form-check-label">Disable CRU frame shift</label>
+      </div>
+      <div class="form-check">
+        <input data-id="NPZz" class="form-check-input" type="checkbox" data-inchi-option-on="NPZz">
+        <label class="form-check-label">Allow non-polymer Zz pseudoatoms</label>
+      </div>
+      <div class="mt-2">
+        <a style="text-decoration:none;" role="button" data-reset-inchi-options><i class="bi bi-arrow-clockwise pe-2"></i>Reset InChI Options</a>
+      </div>
+    </template>
+
+    <!-- Template for InChI 1.07 options -->
+    <template data-inchi-options-template-version="1.07-RC1">
       <div class="form-check">
         <input data-id="mobileH" class="form-check-input" type="checkbox" data-inchi-option-off="DoNotAddH" data-default-checked checked>
         <label class="form-check-label">Mobile H Perception</label>

--- a/pages/index.html
+++ b/pages/index.html
@@ -611,14 +611,14 @@
       <div class="form-check">
       <select data-tautomer-multiselect multiple="multiple">
         <option data-role="divider"></option>
-        <option data-id="KET" data-inchi-option-on="KET">KET - Keto-enol Tautomerism</option>
-        <option data-id="15T" data-inchi-option-on="15T">15T - 1,5-tautomerism</option>
-        <option data-id="PT_06_00" data-inchi-option-on="PT_06_00">PT_06_00 - 1,3 heteroatom H-shift</option>
-        <option data-id="PT_13_00" data-inchi-option-on="PT_13_00">PT_13_00 - keten-inol exchange</option>
-        <option data-id="PT_16_00" data-inchi-option-on="PT_16_00">PT_16_00 - nitroso/oxime</option>
-        <option data-id="PT_18_00" data-inchi-option-on="PT_18_00">PT_18_00 - cyanic/iso-cyanic acids</option>
-        <option data-id="PT_22_00" data-inchi-option-on="PT_22_00">PT_22_00 - imine/imine</option>
-        <option data-id="PT_39_00" data-inchi-option-on="PT_39_00">PT_39_00 - nitrone/azoxy or Behrend rearrangement</option>
+        <option data-id="KET" data-inchi-option-on="KET" value="KET">KET - Keto-enol Tautomerism</option>
+        <option data-id="15T" data-inchi-option-on="15T" value="15T">15T - 1,5-tautomerism</option>
+        <option data-id="PT_06_00" data-inchi-option-on="PT_06_00" value="PT_06_00">PT_06_00 - 1,3 heteroatom H-shift</option>
+        <option data-id="PT_13_00" data-inchi-option-on="PT_13_00" value="PT_13_00">PT_13_00 - keten-inol exchange</option>
+        <option data-id="PT_16_00" data-inchi-option-on="PT_16_00" value="PT_16_00">PT_16_00 - nitroso/oxime</option>
+        <option data-id="PT_18_00" data-inchi-option-on="PT_18_00" value="PT_18_00">PT_18_00 - cyanic/iso-cyanic acids</option>
+        <option data-id="PT_22_00" data-inchi-option-on="PT_22_00" value="PT_22_00">PT_22_00 - imine/imine</option>
+        <option data-id="PT_39_00" data-inchi-option-on="PT_39_00" value="PT_39_00">PT_39_00 - nitrone/azoxy or Behrend rearrangement</option>
       </select>
       </div>
       <div class="form-check">

--- a/pages/index.html
+++ b/pages/index.html
@@ -561,7 +561,7 @@
     </template>
 
     <!-- Template for InChI 1.07 options -->
-    <template data-inchi-options-template-version="1.07-RC1">
+    <template data-inchi-options-template-version="1.07-RC2">
       <div class="form-check">
         <input data-id="mobileH" class="form-check-input" type="checkbox" data-inchi-option-off="DoNotAddH" data-default-checked checked>
         <label class="form-check-label">Mobile H Perception</label>

--- a/pages/index.html
+++ b/pages/index.html
@@ -478,78 +478,78 @@
     <!-- Template for InChI options -->
     <template id="inchiOptionsTemplate">
       <div class="form-check">
-        <input id="mobileH" class="form-check-input" type="checkbox" data-inchi-option-off="DoNotAddH" data-default-checked checked>
-        <label class="form-check-label" for="mobileH">Mobile H Perception</label>
+        <input data-id="mobileH" class="form-check-input" type="checkbox" data-inchi-option-off="DoNotAddH" data-default-checked checked>
+        <label class="form-check-label">Mobile H Perception</label>
       </div>
       <div class="row row-cols-auto">
         <div class="col">
           <div class="form-check">
-            <input id="includeStereo" class="form-check-input" type="checkbox" data-inchi-option-off="SNon" data-default-checked checked>
-            <label class="form-check-label" for="includeStereo">Include Stereo:</label>
+            <input data-id="includeStereo" class="form-check-input" type="checkbox" data-inchi-option-off="SNon" data-default-checked checked>
+            <label class="form-check-label">Include Stereo:</label>
           </div>
         </div>
         <div class="col">
           <div class="form-check ms-xl-0 ms-lg-4">
-            <input id="SAbs" class="form-check-input" type="radio" name="stereoRadio" data-inchi-stereo-option data-default-checked checked>
-            <label class="form-check-label" for="SAbs">Absolute</label>
+            <input data-id="SAbs" class="form-check-input" type="radio" name="stereoRadio" data-inchi-stereo-option data-default-checked checked>
+            <label class="form-check-label">Absolute</label>
           </div>
           <div class="form-check ms-xl-0 ms-lg-4">
-            <input id="SRel" class="form-check-input" type="radio" name="stereoRadio" data-inchi-option-on="SRel" data-inchi-stereo-option>
-            <label class="form-check-label" for="SRel">Relative</label>
+            <input data-id="SRel" class="form-check-input" type="radio" name="stereoRadio" data-inchi-option-on="SRel" data-inchi-stereo-option>
+            <label class="form-check-label">Relative</label>
           </div>
           <div class="form-check ms-xl-0 ms-lg-4">
-            <input id="SRac" class="form-check-input" type="radio" name="stereoRadio" data-inchi-option-on="SRac" data-inchi-stereo-option>
-            <label class="form-check-label" for="SRac">Racemic</label>
+            <input data-id="SRac" class="form-check-input" type="radio" name="stereoRadio" data-inchi-option-on="SRac" data-inchi-stereo-option>
+            <label class="form-check-label">Racemic</label>
           </div>
           <div class="form-check ms-xl-0 ms-lg-4">
-            <input id="SUCF" class="form-check-input" type="radio" name="stereoRadio" data-inchi-option-on="SUCF" data-inchi-stereo-option>
-            <label class="form-check-label" for="SUCF">From chiral flag</label>
+            <input data-id="SUCF" class="form-check-input" type="radio" name="stereoRadio" data-inchi-option-on="SUCF" data-inchi-stereo-option>
+            <label class="form-check-label">From chiral flag</label>
           </div>
         </div>
       </div>
       <div class="form-check ms-4">
-        <input id="SUU" class="form-check-input" type="checkbox" data-inchi-option-on="SUU" data-inchi-stereo-option>
-        <label class="form-check-label" for="SUU">Always include omitted/undefined stereo</label>
+        <input data-id="SUU" class="form-check-input" type="checkbox" data-inchi-option-on="SUU" data-inchi-stereo-option>
+        <label class="form-check-label">Always include omitted/undefined stereo</label>
       </div>
       <div class="form-check ms-4">
-        <input id="SLUUD" class="form-check-input" type="checkbox" data-inchi-option-on="SLUUD" data-inchi-stereo-option>
-        <label class="form-check-label" for="SLUUD">Different marks for unknown/undefined stereo</label>
+        <input data-id="SLUUD" class="form-check-input" type="checkbox" data-inchi-option-on="SLUUD" data-inchi-stereo-option>
+        <label class="form-check-label">Different marks for unknown/undefined stereo</label>
       </div>
       <div class="form-check ms-4">
-        <input id="NEWPSOFF" class="form-check-input" type="checkbox" data-inchi-option-on="NEWPSOFF" data-inchi-stereo-option>
-        <label class="form-check-label" for="NEWPSOFF">Both ends of wedge point to stereocenters</label>
+        <input data-id="NEWPSOFF" class="form-check-input" type="checkbox" data-inchi-option-on="NEWPSOFF" data-inchi-stereo-option>
+        <label class="form-check-label">Both ends of wedge point to stereocenters</label>
       </div>
       <div class="form-check">
-        <input id="RecMet" class="form-check-input" type="checkbox" data-inchi-option-on="RecMet">
-        <label class="form-check-label" for="RecMet">Include Bonds to Metal</label>
+        <input data-id="RecMet" class="form-check-input" type="checkbox" data-inchi-option-on="RecMet">
+        <label class="form-check-label">Include Bonds to Metal</label>
       </div>
       <div class="form-check">
-        <input id="KET" class="form-check-input" type="checkbox" data-inchi-option-on="KET">
-        <label class="form-check-label" for="KET">Keto-enol Tautomerism</label>
+        <input data-id="KET" class="form-check-input" type="checkbox" data-inchi-option-on="KET">
+        <label class="form-check-label">Keto-enol Tautomerism</label>
       </div>
       <div class="form-check">
-        <input id="15T" class="form-check-input" type="checkbox" data-inchi-option-on="15T">
-        <label class="form-check-label" for="15T">1,5-tautomerism</label>
+        <input data-id="15T" class="form-check-input" type="checkbox" data-inchi-option-on="15T">
+        <label class="form-check-label">1,5-tautomerism</label>
       </div>
       <div class="form-check">
-        <input id="treatPolymers" class="form-check-input" type="checkbox" data-inchi-option-on="Polymers">
-        <label class="form-check-label" for="treatPolymers">Treat polymers:</label>
+        <input data-id="treatPolymers" class="form-check-input" type="checkbox" data-inchi-option-on="Polymers">
+        <label class="form-check-label">Treat polymers:</label>
       </div>
       <div class="form-check ms-4">
-        <input id="NoEdits" class="form-check-input" type="checkbox" data-inchi-option-on="NoEdits" data-inchi-polymer-option data-default-disabled disabled>
-        <label class="form-check-label" for="NoEdits">No pre-edits of original polymer structure</label>
+        <input data-id="NoEdits" class="form-check-input" type="checkbox" data-inchi-option-on="NoEdits" data-inchi-polymer-option data-default-disabled disabled>
+        <label class="form-check-label">No pre-edits of original polymer structure</label>
       </div>
       <div class="form-check ms-4">
-        <input id="FoldCRU" class="form-check-input" type="checkbox" data-inchi-option-on="FoldCRU" data-inchi-polymer-option data-default-disabled disabled>
-        <label class="form-check-label" for="FoldCRU">Enable CRU folding</label>
+        <input data-id="FoldCRU" class="form-check-input" type="checkbox" data-inchi-option-on="FoldCRU" data-inchi-polymer-option data-default-disabled disabled>
+        <label class="form-check-label">Enable CRU folding</label>
       </div>
       <div class="form-check ms-4">
-        <input id="NoFrameShift" class="form-check-input" type="checkbox" data-inchi-option-on="NoFrameShift" data-inchi-polymer-option data-default-disabled disabled>
-        <label class="form-check-label" for="NoFrameShift">Disable CRU frame shift</label>
+        <input data-id="NoFrameShift" class="form-check-input" type="checkbox" data-inchi-option-on="NoFrameShift" data-inchi-polymer-option data-default-disabled disabled>
+        <label class="form-check-label">Disable CRU frame shift</label>
       </div>
       <div class="form-check">
-        <input id="NPZz" class="form-check-input" type="checkbox" data-inchi-option-on="NPZz">
-        <label class="form-check-label" for="NPZz">Allow non-polymer Zz pseudoatoms</label>
+        <input data-id="NPZz" class="form-check-input" type="checkbox" data-inchi-option-on="NPZz">
+        <label class="form-check-label">Allow non-polymer Zz pseudoatoms</label>
       </div>
       <div class="mt-2">
         <a style="text-decoration:none;" role="button" data-reset-inchi-options><i class="bi bi-arrow-clockwise pe-2"></i>Reset InChI Options</a>

--- a/pages/index.html
+++ b/pages/index.html
@@ -73,10 +73,10 @@
                   </div>
                 </div>
                 <div class="col-xl-4 mt-auto">
-                  <div id="inchi-tab1-options"></div>
+                  <div data-inchi-options></div>
                   <div class="mt-2">
                     <label class="form-check-label mb-2" for="inchi-tab1-inchiversion">Select InChI version</label>
-                    <select id="inchi-tab1-inchiversion" class="form-select" onchange="updateInchiTab1()"></select>
+                    <select id="inchi-tab1-inchiversion" class="form-select" data-version onchange="updateInchiTab1()"></select>
                   </div>
                 </div>
               </div>
@@ -118,10 +118,10 @@
                   </div>
                 </div>
                 <div class="col-xl-4 mt-auto">
-                  <div id="inchi-tab2-options"></div>
+                  <div data-inchi-options></div>
                   <div class="mt-2">
                     <label class="form-check-label mb-2" for="inchi-tab2-inchiversion">Select InChI version</label>
-                    <select id="inchi-tab2-inchiversion" class="form-select" onchange="updateInchiTab2()"></select>
+                    <select id="inchi-tab2-inchiversion" class="form-select" data-version onchange="updateInchiTab2()"></select>
                   </div>
                 </div>
               </div>
@@ -164,7 +164,7 @@
                 <div class="col-xl-4 mt-auto">
                   <div class="mt-2">
                     <label class="form-check-label mb-2" for="inchi-tab3-inchiversion">Select InChI version</label>
-                    <select id="inchi-tab3-inchiversion" class="form-select" onchange="updateInchiTab3()"></select>
+                    <select id="inchi-tab3-inchiversion" class="form-select" data-version onchange="updateInchiTab3()"></select>
                   </div>
                 </div>
               </div>
@@ -220,7 +220,7 @@
                 <div class="col-xl-4 mt-auto">
                   <div class="mt-2">
                     <label class="form-check-label mb-2" for="rinchi-tab1-rinchiversion">Select RInChI version</label>
-                    <select id="rinchi-tab1-rinchiversion" class="form-select" onchange="updateRinchiTab1()"></select>
+                    <select id="rinchi-tab1-rinchiversion" class="form-select" data-version onchange="updateRinchiTab1()"></select>
                   </div>
                 </div>
               </div>
@@ -280,7 +280,7 @@
                   </div>
                   <div class="mt-2">
                     <label class="form-check-label mb-2" for="rinchi-tab2-rinchiversion">Select RInChI version</label>
-                    <select id="rinchi-tab2-rinchiversion" class="form-select" onchange="updateRinchiTab2()"></select>
+                    <select id="rinchi-tab2-rinchiversion" class="form-select" data-version onchange="updateRinchiTab2()"></select>
                   </div>
                 </div>
               </div>
@@ -340,7 +340,7 @@
                 <div class="col-xl-4 mt-auto">
                   <div class="mt-4">
                     <label class="form-check-label mb-2" for="rinchi-tab3-rinchiversion">Select RInChI version</label>
-                    <select id="rinchi-tab3-rinchiversion" class="form-select" onchange="updateRinchiTab3()"></select>
+                    <select id="rinchi-tab3-rinchiversion" class="form-select" data-version onchange="updateRinchiTab3()"></select>
                   </div>
                 </div>
               </div>
@@ -391,7 +391,7 @@
                   </div>
                   <div class="mt-4">
                     <label class="form-check-label mb-2" for="rinchi-tab4-rinchiversion">Select RInChI version</label>
-                    <select id="rinchi-tab4-rinchiversion" class="form-select" onchange="updateRinchiTab4()"></select>
+                    <select id="rinchi-tab4-rinchiversion" class="form-select" data-version onchange="updateRinchiTab4()"></select>
                   </div>
                 </div>
               </div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -14,8 +14,12 @@
 
     <link href="css/index.css" rel="stylesheet">
     <link href="bootstrap/bootstrap-5.2.3-dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+    <!-- Only bootstrap-multiselect needs jQuery. -->
+    <script src="jquery/jquery-3.7.1.min.js" integrity="sha384-1H217gwSVyLSIfaLxHbE7dRb3v4mYCKbpQvzx0cegeju1MVsGrX5xXxAvs/HgeFs" crossorigin="anonymous"></script>
     <script src="bootstrap/bootstrap-5.2.3-dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
     <link href="bootstrap-icons/bootstrap-icons-1.10.3/bootstrap-icons.css" rel="stylesheet" integrity="sha384-b6lVK+yci+bfDmaY1u0zE8YYJt0TZxLEAFyYSLHId4xoVvsrQu3INevFKo+Xir8e" crossorigin="anonymous">
+    <script src="bootstrap-multiselect/js/bootstrap-multiselect.min.js" integrity="sha384-0bKqY/QpXas8sskCT4hKi1EsfrCHXH7kZYNMr05pTeUbEdxf5xdjxEy1fjdU861x" crossorigin="anonymous"></script>
+    <link href="bootstrap-multiselect/css/bootstrap-multiselect.min.css" rel="stylesheet" integrity="sha384-sRRK8QIx/nQdgIMFawlqpzKW5yaVcx63vbU82I9nuHAdsQN/blJQNrf6GORupDMI" crossorigin="anonymous">
   </head>
   <body onload="onBodyLoad()">
     <div class="container-md" style="margin-bottom: 2rem;">

--- a/pages/index.html
+++ b/pages/index.html
@@ -609,12 +609,17 @@
         <label class="form-check-label">Include Bonds to Metal</label>
       </div>
       <div class="form-check">
-        <input data-id="KET" class="form-check-input" type="checkbox" data-inchi-option-on="KET">
-        <label class="form-check-label">Keto-enol Tautomerism</label>
-      </div>
-      <div class="form-check">
-        <input data-id="15T" class="form-check-input" type="checkbox" data-inchi-option-on="15T">
-        <label class="form-check-label">1,5-tautomerism</label>
+      <select data-tautomer-multiselect multiple="multiple">
+        <option data-role="divider"></option>
+        <option data-id="KET" data-inchi-option-on="KET">KET - Keto-enol Tautomerism</option>
+        <option data-id="15T" data-inchi-option-on="15T">15T - 1,5-tautomerism</option>
+        <option data-id="PT_06_00" data-inchi-option-on="PT_06_00">PT_06_00 - 1,3 heteroatom H-shift</option>
+        <option data-id="PT_13_00" data-inchi-option-on="PT_13_00">PT_13_00 - keten-inol exchange</option>
+        <option data-id="PT_16_00" data-inchi-option-on="PT_16_00">PT_16_00 - nitroso/oxime</option>
+        <option data-id="PT_18_00" data-inchi-option-on="PT_18_00">PT_18_00 - cyanic/iso-cyanic acids</option>
+        <option data-id="PT_22_00" data-inchi-option-on="PT_22_00">PT_22_00 - imine/imine</option>
+        <option data-id="PT_39_00" data-inchi-option-on="PT_39_00">PT_39_00 - nitrone/azoxy or Behrend rearrangement</option>
+      </select>
       </div>
       <div class="form-check">
         <input data-id="treatPolymers" class="form-check-input" type="checkbox" data-inchi-option-on="Polymers">

--- a/pages/index.js
+++ b/pages/index.js
@@ -43,7 +43,7 @@ function addInchiOptions(targetDivId, updateFunction) {
    * Register an on-change event on the "Include Stereo" checkbox to switch the
    * 'disabled' state of the inputs that cope with stereo options.
    */
-  clone.getElementById("includeStereo").addEventListener("change", function() {
+  clone.querySelector("input.form-check-input[data-id=\"includeStereo\"]").addEventListener("change", function() {
     document.getElementById(targetDivId).querySelectorAll("input.form-check-input[data-inchi-stereo-option]").forEach(input => {
       input.disabled = !this.checked;
     });
@@ -53,7 +53,7 @@ function addInchiOptions(targetDivId, updateFunction) {
    * Register an on-change event on the "Treat polymers" checkbox to switch the
    * 'disabled' state of the inputs that cope with polymer options.
    */
-  clone.getElementById("treatPolymers").addEventListener("change", function() {
+  clone.querySelector("input.form-check-input[data-id=\"treatPolymers\"]").addEventListener("change", function() {
     document.getElementById(targetDivId).querySelectorAll("input.form-check-input[data-inchi-polymer-option]").forEach(input => {
       input.disabled = !this.checked;
     });
@@ -68,14 +68,13 @@ function addInchiOptions(targetDivId, updateFunction) {
   });
 
   /*
-   * Reassign ids of all <input> elements and change the target id of their
+   * Assign ids to all <input> elements and assign the target id of their
    * <label> element accordingly. Also register an on-change event to call
    * updateFunction.
    */
   clone.querySelectorAll("input.form-check-input").forEach(input => {
-    const newId = input.id + "-" + targetDivId;
-    input.id = newId;
-    input.nextElementSibling.htmlFor = newId;
+    input.id = input.dataset.id + "-" + targetDivId;
+    input.nextElementSibling.htmlFor = input.id;
 
     input.addEventListener("change", updateFunction);
   });

--- a/pages/index.js
+++ b/pages/index.js
@@ -106,18 +106,25 @@ function addInchiOptionsForm(tabDivId, updateFunction) {
 
 function resetInchiOptions(targetDivId) {
   const targetDiv = document.getElementById(targetDivId);
+
   targetDiv.querySelectorAll("input.form-check-input[data-default-checked]").forEach(input => {
     input.checked = true;
   });
+
   targetDiv.querySelectorAll("input.form-check-input:not([data-default-checked])").forEach(input => {
     input.checked = false;
   });
+
   targetDiv.querySelectorAll("input.form-check-input[data-default-disabled]").forEach(input => {
     input.disabled = true;
   });
+
   targetDiv.querySelectorAll("input.form-check-input:not([data-default-disabled])").forEach(input => {
     input.disabled = false;
   });
+
+  // Bootstrap Multiselect widget for tautomer options
+  $(targetDiv).find("select[data-tautomer-multiselect]").multiselect('deselectAll', false);
 }
 
 function getInchiOptions(tabId) {
@@ -133,8 +140,8 @@ function getInchiOptions(tabId) {
   });
 
   // Bootstrap Multiselect widget for tautomer options
-  tabDiv.querySelectorAll("select[data-tautomer-multiselect] option[data-inchi-option-on]:checked").forEach(input => {
-    options.push(input.dataset.inchiOptionOn);
+  tabDiv.querySelectorAll("select[data-tautomer-multiselect] option[data-inchi-option-on]:checked").forEach(optionElement => {
+    options.push(optionElement.dataset.inchiOptionOn);
   });
 
   return options;

--- a/pages/index.js
+++ b/pages/index.js
@@ -83,6 +83,22 @@ function addInchiOptionsForm(tabDivId, updateFunction) {
     input.addEventListener("change", updateFunction);
   });
 
+  /*
+   * Initialize the Bootstrap Multiselect widget for tautomer options if it exists.
+   */
+  $(clone).find("select[data-tautomer-multiselect]").multiselect({
+    includeSelectAllOption: true,
+    nonSelectedText: "Tautomer options",
+    numberDisplayed: 1,
+    onChange: () => updateFunction(),
+    onDeselectAll: () => updateFunction(),
+    onSelectAll: () => updateFunction(),
+    // Workaround for Bootstrap 5
+    templates: {
+      button: '<button type="button" class="form-select multiselect dropdown-toggle" data-bs-toggle="dropdown"><span class="multiselect-selected-text"></span></button>'
+    },
+  });
+
   // Attach to target element
   targetDiv.innerHTML = "";
   targetDiv.appendChild(clone);
@@ -114,6 +130,11 @@ function getInchiOptions(tabId) {
 
   tabDiv.querySelectorAll("input.form-check-input:enabled[data-inchi-option-off]:not(:checked)").forEach(input => {
     options.push(input.dataset.inchiOptionOff);
+  });
+
+  // Bootstrap Multiselect widget for tautomer options
+  tabDiv.querySelectorAll("select[data-tautomer-multiselect] option[data-inchi-option-on]:checked").forEach(input => {
+    options.push(input.dataset.inchiOptionOn);
   });
 
   return options;

--- a/pages/index.js
+++ b/pages/index.js
@@ -87,6 +87,7 @@ function addInchiOptionsForm(tabDivId, updateFunction) {
    * Initialize the Bootstrap Multiselect widget for tautomer options if it exists.
    */
   $(clone).find("select[data-tautomer-multiselect]").multiselect({
+    buttonContainer: '<div class="btn-group mw-100"></div>',
     includeSelectAllOption: true,
     nonSelectedText: "Tautomer options",
     numberDisplayed: 1,

--- a/pages/index.js
+++ b/pages/index.js
@@ -122,9 +122,7 @@ function collectInchiOptions(tabId) {
 }
 
 function getVersion(tabId) {
-  const version = document.getElementById(tabId).querySelector("select[data-version]").value;
-  console.log("version:" + version);
-  return version;
+  return document.getElementById(tabId).querySelector("select[data-version]").value;
 }
 
 /*

--- a/pages/index.js
+++ b/pages/index.js
@@ -124,7 +124,7 @@ function resetInchiOptions(targetDivId) {
   });
 
   // Bootstrap Multiselect widget for tautomer options
-  $(targetDiv).find("select[data-tautomer-multiselect]").multiselect('deselectAll', false);
+  $(targetDiv).find("select[data-tautomer-multiselect]").multiselect("deselectAll", false);
 }
 
 function getInchiOptions(tabId) {
@@ -157,10 +157,15 @@ function getVersion(tabId) {
 
 function getInchiOptionsState(tabDivId) {
   const inchiOptionsDiv = document.getElementById(tabDivId).querySelector("div[data-inchi-options]");
-
   const optionsState = {};
+
   inchiOptionsDiv.querySelectorAll("input[data-id]").forEach(input => {
     optionsState[input.dataset.id] = [ input.checked, input.disabled ];
+  });
+
+  // Bootstrap Multiselect widget for tautomer options
+  inchiOptionsDiv.querySelectorAll("select[data-tautomer-multiselect] option[data-id]").forEach(optionElement => {
+    optionsState[optionElement.dataset.id] = [ optionElement.selected, optionElement.disabled ];
   });
 
   return optionsState
@@ -174,6 +179,12 @@ function applyInchiOptionsState(tabDivId, optionsState) {
     if (input) {
       input.checked = v[0];
       input.disabled = v[1];
+      return;
+    }
+
+    // Bootstrap Multiselect widget for tautomer options
+    if (v[0]) {
+      $(inchiOptionsDiv).find("select[data-tautomer-multiselect]").multiselect("select", k);
     }
   });
 }


### PR DESCRIPTION
Extend the set of InChI parameters with InChI 1.07's new tautomer options `PT_06_00`, `PT_13_00`, `PT_16_00`, `PT_18_00`, `PT_22_00` and `PT_39_00`. Examples for and descriptions of these options can be found in [Marc C. Nicklaus' talk _Tautomers in InChI_](https://www.inchi-trust.org/wp/wp-content/uploads/2022/11/Day_1_Nicklaus_Tautomerism_2021-03-21A.pdf) and in [Dhaked _et al._ Toward a Comprehensive Treatment of Tautomerism in Chemoinformatics Including in InChI V2, _J. Chem. Inf. Model._ (2020), 60, 1253–1275, doi:10.1021/acs.jcim.9b01080](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8459712/).

#### Significant changes:
- InChI options specific to the InChI version; switching InChI versions preserves the selected options (only applies to options that are present in both versions)
- Addition of the 6 new tautomer options in the InChI 1.07 options template. By default, they are unchecked - similar to the existing two tautomer options `15T` and `KET`.

#### Implementation decisions:
Concerning the website design, adding 6 new options would introduce significant space problems and future InChI versions will support even more tautomer rules. Thus, the selection of the tautomer options is achieved via a single "multiselect" component.
The only suitable component I could find is [Bootstrap Multiselect](https://davidstutz.github.io/bootstrap-multiselect/), which is highly configurable and even offers [collapsible groups](https://davidstutz.github.io/bootstrap-multiselect/#configuration-options-collapseOptGroupsByDefault) (e.g. for grouping by tautomerism type - prototropic, ring-chain and valence tautomerism) and [text filtering](https://davidstutz.github.io/bootstrap-multiselect/#configuration-options-enableFiltering) that could be leveraged in future additions of tautomer rules. Unfortunately, this project is not actively maintained and compatible with Bootstrap 4 (we use 5.2.3), but I think it's worth taking the risk. Compatibility to Bootstrap 5 is achieved by using a custom rendering template for this component.

#### Browser issues:
When having at least one tautomer option selected in the multiselect component the otherwise white button changes colour (dark green). This feature uses the `:has()` pseudo-class in a CSS selector that may not be available in all modern web browsers (see [Can I use](https://caniuse.com/css-has)). If `:has()` is not available, the button simply stays white.