### PR TITLE
Replace R with Zz pseudoatoms when NPZz option is enabled

### DIFF
--- a/pages/css/index.css
+++ b/pages/css/index.css
@@ -52,3 +52,12 @@ button.form-select.multiselect:focus {
   --bs-aspect-ratio:62%;
   min-height:530px;
 }
+
+.colored-icon {
+  color: #00612c;
+}
+
+.npzz-tooltip .tooltip-inner {
+  max-width: 500px !important;
+  text-align: left !important;
+}

--- a/pages/index.html
+++ b/pages/index.html
@@ -80,7 +80,7 @@
                   <div data-inchi-options></div>
                   <div class="mt-2">
                     <label class="form-check-label mb-2" for="inchi-tab1-inchiversion">Select InChI version</label>
-                    <select id="inchi-tab1-inchiversion" class="form-select" data-version onchange="onChangeInChIVersionTab1()"></select>
+                    <select id="inchi-tab1-inchiversion" class="form-select" data-version onchange="onChangeInChIVersionTab1(); initTooltips();"></select>
                   </div>
                 </div>
               </div>
@@ -125,7 +125,7 @@
                   <div data-inchi-options></div>
                   <div class="mt-2">
                     <label class="form-check-label mb-2" for="inchi-tab2-inchiversion">Select InChI version</label>
-                    <select id="inchi-tab2-inchiversion" class="form-select" data-version onchange="onChangeInChIVersionTab2()"></select>
+                    <select id="inchi-tab2-inchiversion" class="form-select" data-version onchange="onChangeInChIVersionTab2(); initTooltips();"></select>
                   </div>
                 </div>
               </div>
@@ -553,7 +553,7 @@
       </div>
       <div class="form-check">
         <input data-id="NPZz" class="form-check-input" type="checkbox" data-inchi-option-on="NPZz">
-        <label class="form-check-label">Allow non-polymer Zz pseudoatoms</label>
+        <label class="form-check-label">Allow non-polymer Zz pseudoatoms <i class="bi bi-question-circle-fill colored-icon" data-bs-toggle="tooltip" data-bs-custom-class="npzz-tooltip" data-bs-html="true" data-bs-title='The "Zz" or "*" ("star") pseudoatom is a generic placeholder designating an entity of undefined/unknown/variable nature. It is typically used for handling polymers, but may also be used outside the polymer context with this InChI option (<i>NPZz</i>). See the InChI Technical Manual, section IV. "g. Zz (star, pseudo element) atoms", for details.<br /><br />How to draw?<br />The drawing of "Zz" or "*" pseudoatoms is not possible within the Ketcher structure editor. Please use the "R" pseudoatom instead (hotkey "R" when having an atom selected or when hovering over an atom). Upon transformation with the <i>NPZz</i> option the InChI Web Demo will rename all "R" atoms to "Zz".'></i></label>
       </div>
       <div class="mt-2">
         <a style="text-decoration:none;" role="button" data-reset-inchi-options><i class="bi bi-arrow-clockwise pe-2"></i>Reset InChI Options</a>
@@ -639,7 +639,7 @@
       </div>
       <div class="form-check">
         <input data-id="NPZz" class="form-check-input" type="checkbox" data-inchi-option-on="NPZz">
-        <label class="form-check-label">Allow non-polymer Zz pseudoatoms</label>
+        <label class="form-check-label">Allow non-polymer Zz pseudoatoms <i class="bi bi-question-circle-fill colored-icon" data-bs-toggle="tooltip" data-bs-custom-class="npzz-tooltip" data-bs-html="true" data-bs-title='The "Zz" or "*" ("star") pseudoatom is a generic placeholder designating an entity of undefined/unknown/variable nature. It is typically used for handling polymers, but may also be used outside the polymer context with this InChI option (<i>NPZz</i>). See the InChI Technical Manual, section IV. "g. Zz (star, pseudo element) atoms", for details.<br /><br />How to draw?<br />The drawing of "Zz" or "*" pseudoatoms is not possible within the Ketcher structure editor. Please use the "R" pseudoatom instead (hotkey "R" when having an atom selected or when hovering over an atom). Upon transformation with the <i>NPZz</i> option the InChI Web Demo will rename all "R" atoms to "Zz".'></i></label>
       </div>
       <div class="mt-2">
         <a style="text-decoration:none;" role="button" data-reset-inchi-options><i class="bi bi-arrow-clockwise pe-2"></i>Reset InChI Options</a>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,10 @@
 "use strict";
 
 /*
- * Page loaded:
- * - initialize user-selectable parameters
+ * Page loaded
  */
 function onBodyLoad() {
+  // initialize user-selectable parameters
   addVersions("inchi-tab1-pane", availableInchiVersions);
   addInchiOptionsForm("inchi-tab1-pane", () => updateInchiTab1());
 
@@ -17,6 +17,9 @@ function onBodyLoad() {
   addVersions("rinchi-tab2-pane", availableRInchiVersions);
   addVersions("rinchi-tab3-pane", availableRInchiVersions);
   addVersions("rinchi-tab4-pane", availableRInchiVersions);
+
+  // enable tooltips
+  initTooltips();
 }
 
 function addVersions(tabDivId, versions) {
@@ -128,6 +131,12 @@ function resetInchiOptions(targetDivId) {
 
   // Bootstrap Multiselect widget for tautomer options
   $(targetDiv).find("select[data-tautomer-multiselect]").multiselect("deselectAll", false);
+}
+
+function initTooltips() {
+  [...document.querySelectorAll('[data-bs-toggle="tooltip"]')].map(tooltipTriggerEl => {
+    new bootstrap.Tooltip(tooltipTriggerEl);
+  });
 }
 
 function getInchiOptions(tabId) {


### PR DESCRIPTION
**Problem**
InChI can process "*" ("star") or "Zz" pseudoatoms outside the polymer context using the _NPZz_ option (see [InChI TechMan](https://github.com/IUPAC-InChI/InChI/blob/f8112db2168bb0f00456685ec3fd418df84a1c3c/INCHI-1-DOC/InChI_TechMan.pdf) section IV). On the other hand, the Ketcher structure editor does not allow the drawing of these pseudoatoms.

**Solution**
Users draw the "R" pseudoatom instead. In case _NPZz_ is enabled the program logic replaces all "R" atom labels with "Zz" in Ketcher's internal data structure before exporting the Molfile from Ketcher and passing it to the InChI API.