### PR TITLE
Use latest revision of RInChI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,19 +111,26 @@ jobs:
       - name: Checkout RInChI repository
         uses: actions/checkout@v4
         with:
-          path: './RInChI'
+          path: './RInChI/RInChI'
           repository: 'IUPAC-InChI/RInChI'
-          ref: '0e14efe8ca7509262fe7b7aecd8c900ef00ffd9f'
+          ref: 'd122a78457c592b9728906f3c0b565a2c2c5d6dd'
+
+      - name: Checkout v1.07 from InChI repository
+        uses: actions/checkout@v4
+        with:
+          path: './RInChI/InChI'
+          repository: 'IUPAC-InChI/InChI'
+          ref: 'v1.07.1'
 
       - name: Patch RInChI project
         run: |
-          cd $GITHUB_WORKSPACE/RInChI
+          cd $GITHUB_WORKSPACE/RInChI/RInChI
           git apply $GITHUB_WORKSPACE/InChI-Web-Demo/rinchi/rinchi.patch
 
       - name: Compile RInChI WebAssembly module from rinchi_lib
-        # Creates librinchi-100.js and librinchi-100.wasm in $GITHUB_WORKSPACE/RInChI/src/rinchi_lib
+        # Creates librinchi-1.1.js and librinchi-1.1.wasm in $GITHUB_WORKSPACE/RInChI/RInChI/src/rinchi_lib
         run: |
-          cd $GITHUB_WORKSPACE/RInChI/src/rinchi_lib
+          cd $GITHUB_WORKSPACE/RInChI/RInChI/src/rinchi_lib
           make -j -f Makefile-32bit
 
       #
@@ -187,7 +194,7 @@ jobs:
           cp $GITHUB_WORKSPACE/InChI_1_06/INCHI-1-SRC/INCHI_WEB/inchi-web106.* inchi
           cp $GITHUB_WORKSPACE/InChI_1_07/INCHI-1-SRC/INCHI_WEB/inchi-web107.* inchi
           mkdir rinchi
-          cp $GITHUB_WORKSPACE/RInChI/src/rinchi_lib/librinchi-100.* rinchi
+          cp $GITHUB_WORKSPACE/RInChI/RInChI/src/rinchi_lib/librinchi-1.1.* rinchi
           mkdir ketcher
           cp -R $GITHUB_WORKSPACE/InChI-Web-Demo/ketcher/react-app/build/* ketcher
           cp -R $GITHUB_WORKSPACE/bootstrap .

--- a/pages/index.html
+++ b/pages/index.html
@@ -10,7 +10,7 @@
     <script type="text/javascript" src="inchi/inchi-web106.js"></script>
 
     <!-- RInChI modules -->
-    <script type="text/javascript" src="rinchi/librinchi-100.js"></script>
+    <script type="text/javascript" src="rinchi/librinchi-1.1.js"></script>
 
     <link href="css/index.css" rel="stylesheet">
     <link href="bootstrap/bootstrap-5.2.3-dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">

--- a/pages/rinchi.js
+++ b/pages/rinchi.js
@@ -7,8 +7,8 @@
  * See https://github.com/emscripten-core/emscripten/blob/fa339b76424ca9fbe5cf15faea0295d2ac8d58cc/src/settings.js#L1183
  */
 const availableRInchiVersions = {
-  "1.00": {
-    "module": rinchiModule100(),
+  "1.1-dev with InChI 1.07.1": {
+    "module": rinchiModule11(),
     "default": true
   }
 };

--- a/rinchi/rinchi.patch
+++ b/rinchi/rinchi.patch
@@ -1,18 +1,19 @@
 diff --git a/src/lib/rinchi_platform.h b/src/lib/rinchi_platform.h
-index df89df6..2ee62d1 100644
+index df89df66..3812749c 100644
 --- a/src/lib/rinchi_platform.h
 +++ b/src/lib/rinchi_platform.h
-@@ -67,7 +67,7 @@
- 	// writing this), we don't need to worry about it.
- 	#define ON_LINUX
- 	const char DIR_SEPARATOR = '/';
--#elif defined(__APPLE__)
-+#elif defined(__APPLE__) || defined(__EMSCRIPTEN__)
+@@ -71,6 +71,9 @@
  	// #define ON_APPLE
  	#define ON_LINUX
  	const char DIR_SEPARATOR = '/';
++#elif defined(__EMSCRIPTEN__)
++	#define ON_LINUX
++	const char DIR_SEPARATOR = '/';
+ #else
+ 	Error Unsupported_platform
+ #endif
 diff --git a/src/rinchi_lib/Makefile-32bit b/src/rinchi_lib/Makefile-32bit
-index 9b1fced..cabc143 100644
+index b3213984..987a73cd 100644
 --- a/src/rinchi_lib/Makefile-32bit
 +++ b/src/rinchi_lib/Makefile-32bit
 @@ -10,11 +10,11 @@ MAKEFILE      = Makefile-32bit
@@ -23,32 +24,32 @@ index 9b1fced..cabc143 100644
 -CXX           = g++
 +CC            = emcc
 +CXX           = em++
- DEFINES       = 
- CFLAGS        = -m32 -pipe -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
+ DEFINES       = -DTARGET_API_LIB
+ CFLAGS        = -m32 -pipe -ansi -DCOMPILE_ANSI_ONLY -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
 -CXXFLAGS      = -m32 -pipe -fvisibility=hidden -O2 -Wall -W -fPIC $(DEFINES)
 +CXXFLAGS      = -m32 -pipe -fvisibility=hidden -O2 -Wall -std=c++11 -W -fPIC $(DEFINES)
- INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../INCHI-1-API/INCHI_API/inchi_dll -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-32
+ INCPATH       = -I. -I../lib -I../parsers -I../rinchi -I../writers -I../../../InChI/INCHI-1-SRC/INCHI_BASE/src
  QMAKE         = /usr/lib/x86_64-linux-gnu/qt5/bin/qmake
  DEL_FILE      = rm -f
 @@ -34,8 +34,10 @@ TAR           = tar -cf
  COMPRESS      = gzip -9f
  DISTNAME      = rinchi1.0.0
- DISTDIR = /home/jhje/RInChI/src/rinchi_lib/.tmp/rinchi1.0.0
+ DISTDIR = /home/jhje/iupac/RInChI/src/rinchi_lib/.tmp/rinchi1.0.0
 -LINK          = g++
 -LFLAGS        = -m32 -Wl,-O1 -shared -Wl,-soname,librinchi.so.1
 +LINK          = em++
 +EXPORTED_FUNCTIONS = _rinchilib_latest_err_msg,_rinchilib_rinchi_from_file_text,_rinchilib_file_text_from_rinchi,_rinchilib_rinchikey_from_rinchi,_malloc,_free
 +EXPORTED_RUNTIME_METHODS = ccall,cwrap,UTF8ToString,getValue
-+LFLAGS        = -m32 -Wl,-O1 -sNO_DISABLE_EXCEPTION_CATCHING -sEXPORTED_FUNCTIONS=$(EXPORTED_FUNCTIONS) -sEXPORTED_RUNTIME_METHODS=$(EXPORTED_RUNTIME_METHODS) -sEXPORT_NAME=rinchiModule100 -sMODULARIZE -sENVIRONMENT=web -sSTACK_SIZE=1048576
++LFLAGS        = -m32 -Wl,-O1 -sNO_DISABLE_EXCEPTION_CATCHING -sEXPORTED_FUNCTIONS=$(EXPORTED_FUNCTIONS) -sEXPORTED_RUNTIME_METHODS=$(EXPORTED_RUNTIME_METHODS) -sEXPORT_NAME=rinchiModule11 -sMODULARIZE -sENVIRONMENT=web -sSTACK_SIZE=1048576
  LIBS          = $(SUBLIBS)  
  AR            = ar cqs
  RANLIB        = 
-@@ -269,7 +271,7 @@ DIST          = /usr/lib/x86_64-linux-gnu/qt5/mkspecs/features/spec_pre.prf \
- 		../../INCHI-1-API/INCHI_API/inchi_dll/util.c
+@@ -245,7 +247,7 @@ DIST          = ../lib/rinchi_utils.cpp \
+ 		../../../InChI/INCHI-1-SRC/INCHI_API/libinchi/src/inchi_dll_b.c
  QMAKE_TARGET  = rinchi
  DESTDIR       = 
 -TARGET        = librinchi.so.1.0.0
-+TARGET        = librinchi-100.js
++TARGET        = librinchi-1.1.js
  TARGETA       = librinchi.a
  TARGET0       = librinchi.so
  TARGETD       = librinchi.so.1.0.0


### PR DESCRIPTION
Since the merge of https://github.com/IUPAC-InChI/RInChI/pull/21 the RInChI repository does not provide the source code of InChI anymore. Instead, InChI sources are now downloaded from the respective git repository.

Other changes:
- The CI workflow now checks out a fixed commit of the RInChI repository ([d122a78](https://github.com/IUPAC-InChI/RInChI/commit/d122a78457c592b9728906f3c0b565a2c2c5d6dd), at the moment head of the main branch) instead of the main branch itself.
- Compile RInChI with InChI v1.07.1
- Rename the RInChI version shown in the UI to "1.1-dev with InChI 1.07.1". Previously the version "1.00" was shown, which was never correct.
- Regenerate the patch file for RInChI's source code